### PR TITLE
Reactivate Skeleton System in Example Scene

### DIFF
--- a/Packages/com.janooba.immersive-interactions/Runtime/ExampleAssets/ExampleScene.unity
+++ b/Packages/com.janooba.immersive-interactions/Runtime/ExampleAssets/ExampleScene.unity
@@ -21659,7 +21659,7 @@ PrefabInstance:
     - target: {fileID: 7050545402952898714, guid: ccf0712c35c2a274cbe18b84259a2ba4,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ccf0712c35c2a274cbe18b84259a2ba4, type: 3}


### PR DESCRIPTION
Skeleton system was deactivated by default in the scene, which could confuse people.